### PR TITLE
fix: arguments order switching limit and offset

### DIFF
--- a/src/Contexts/Backoffice/Courses/application/SearchByCriteria/SearchCoursesByCriteriaQueryHandler.ts
+++ b/src/Contexts/Backoffice/Courses/application/SearchByCriteria/SearchCoursesByCriteriaQueryHandler.ts
@@ -19,6 +19,6 @@ export class SearchCoursesByCriteriaQueryHandler
     const filters = Filters.fromValues(query.filters);
     const order = Order.fromValues(query.orderBy, query.orderType);
 
-    return this.searcher.run(filters, order, query.offset, query.limit);
+    return this.searcher.run(filters, order, query.limit, query.offset);
   }
 }


### PR DESCRIPTION
L22 limit and offset arguments were switched so the searcher was using the limit value instead of offset.