### PR TITLE
Changing way to validate enum values

### DIFF
--- a/src/Contexts/Shared/domain/criteria/FilterOperator.ts
+++ b/src/Contexts/Shared/domain/criteria/FilterOperator.ts
@@ -16,22 +16,13 @@ export class FilterOperator extends EnumValueObject<Operator> {
   }
 
   static fromValue(value: string): FilterOperator {
-    switch (value) {
-      case Operator.EQUAL:
-        return new FilterOperator(Operator.EQUAL);
-      case Operator.NOT_EQUAL:
-        return new FilterOperator(Operator.NOT_EQUAL);
-      case Operator.GT:
-        return new FilterOperator(Operator.GT);
-      case Operator.LT:
-        return new FilterOperator(Operator.LT);
-      case Operator.CONTAINS:
-        return new FilterOperator(Operator.CONTAINS);
-      case Operator.NOT_CONTAINS:
-        return new FilterOperator(Operator.NOT_CONTAINS);
-      default:
-        throw new InvalidArgumentError(`The filter operator ${value} is invalid`);
+    for (const operatorValue of Object.values(Operator)) {
+      if (value === operatorValue.toString()) {
+        return new FilterOperator(operatorValue);
+      }
     }
+
+    throw new InvalidArgumentError(`The filter operator ${value} is invalid`);
   }
 
   public isPositive(): boolean {

--- a/src/Contexts/Shared/domain/criteria/OrderType.ts
+++ b/src/Contexts/Shared/domain/criteria/OrderType.ts
@@ -13,14 +13,13 @@ export class OrderType extends EnumValueObject<OrderTypes> {
   }
 
   static fromValue(value: string): OrderType {
-    switch (value) {
-      case OrderTypes.ASC:
-        return new OrderType(OrderTypes.ASC);
-      case OrderTypes.DESC:
-        return new OrderType(OrderTypes.DESC);
-      default:
-        throw new InvalidArgumentError(`The order type ${value} is invalid`);
+    for (const orderTypeValue of Object.values(OrderTypes)) {
+      if (value === orderTypeValue.toString()) {
+        return new OrderType(orderTypeValue);
+      }
     }
+
+    throw new InvalidArgumentError(`The filter operator ${value} is invalid`);
   }
 
   public isNone(): boolean {

--- a/src/Contexts/Shared/domain/criteria/OrderType.ts
+++ b/src/Contexts/Shared/domain/criteria/OrderType.ts
@@ -19,7 +19,7 @@ export class OrderType extends EnumValueObject<OrderTypes> {
       }
     }
 
-    throw new InvalidArgumentError(`The filter operator ${value} is invalid`);
+    throw new InvalidArgumentError(`The order type ${value} is invalid`);
   }
 
   public isNone(): boolean {


### PR DESCRIPTION
Initially, it uses a switch to validate that enum value is valid.

This seems to be a code smell. If the enum has a lot of entries, the switch statement becomes large and difficult to read. If you use a loop and iterate the enum values using `Object.values` method, this becomes short and easy to mantain. Why?

If you want to add more entries to your enum you don't have to worry about the switch statement that verifies the enum value. You only worry about to add more entries to your enum.